### PR TITLE
press enter to submit password on modal

### DIFF
--- a/public/pmodule/app.js
+++ b/public/pmodule/app.js
@@ -244,6 +244,21 @@ angular.module('passProtect', ['ngAnimate', 'ngSanitize', 'ui.bootstrap','ui', '
    };
 
 /*end whitelist directive*/
+})
+
+/*directive to capture the keypress of the Enter key*/
+.directive('pressEnter', function () {
+    return function (scope, element, attrs) {
+        element.bind("keydown keypress", function (event) {
+            if(event.which === 13) {
+                scope.$apply(function (){
+                    scope.$eval(attrs.pressEnter);
+                });
+
+                event.preventDefault();
+            }
+        });
+    };
 });
 
 

--- a/public/pmodule/templates/pmodal_content.html
+++ b/public/pmodule/templates/pmodal_content.html
@@ -3,7 +3,7 @@
 </div>
 <div class="modal-body" id="modal-body">
     <label class="item item-input">
-        <input ng-model="password" type="password" class="form-control" id="passwordInput" required>
+        <input ng-model="password" type="password" class="form-control" id="passwordInput" press-enter="$password_modal_ctrl.checkPassword(password)" required>
     </label>
     <p class="password-error" ng-show="wrongPassword==true">Sorry, that is not the correct password. Please try again</p>
 </div>


### PR DESCRIPTION
### Summary
Pressing Enter on the keyboard now submits the password on the password modal when opening tests. Previously the user had to click the OK button after entering the password
…

### Reviewer guidance
Open a test form and fill in the required password field, then press enter. This should have the same effect as clicking the OK button

…

### References
#3 

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch
- [ ] PR has 'needs review' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- PR is fully functional
- PR has been tested for [accessibility regressions]
- External dependency files were updated if necessary (node_modules, libraries, etc)
- Documentation is updated
