### PR TITLE
grade 7 test 4 hotfix

### DIFF
--- a/grade_7/grade7_test4.html
+++ b/grade_7/grade7_test4.html
@@ -592,7 +592,7 @@
                         <!-- TODO: Add text input fields for user_id, coach_email -->
                         <!-- Hidden fields for test,course and module -->
                         <input type="hidden" name="test" ng-init="testResponse.test='grade7_test4'">
-                        <input type="hidden" name="course" ng-init="testResponse.course='grade_7_revision'">
+                        <input type="hidden" name="course" ng-init="testResponse.course='grade7_revision'">
                         <input type="hidden" name="module" ng-init="testResponse.module='numeracy'">
                         <div ng-include="'pmodule/templates/validate_coach_id_and_password.html'"></div>
                     </form>

--- a/scripts/schema_upgrade.sh
+++ b/scripts/schema_upgrade.sh
@@ -57,6 +57,10 @@ schema_upgrade(){
 		sqlite3 $1 "insert or ignore into test_marks(test_id,test_name,course,module,testmaxscore) values('grade7_test3','Grade 7 - Number Bases','grade7_revision','numeracy',30);"
 		sqlite3 $1 "insert or ignore into test_marks(test_id,test_name,course,module,testmaxscore) values('grade7_test4','Grade 7 - Profit and Loss & Notation','grade7_revision','numeracy',30);"
 
+		#fix tests with wrong topic
+		echo "Fixing config bug on tests with wrong topic"
+		sqlite3 $1 "update responses set course = 'grade7_revision' where course = 'grade_7_revision'"
+
 		echo "Database schema up to date"
 	fi
 


### PR DESCRIPTION
### Summary
Grade 7 test 4 had the wrong course. It had **grade_7_revision** instead of **grade7_revision**. As a result, the join to test_marks produced NULL, and consequently the test did not appear on the coach dashboard under the tests tab. This PR resolves the problem for grade 7 test 4, and provides a SQL statement to fix any grade 7 tests that have been submitted with the wrong course.
…

### Reviewer guidance
Submit grade 7 test 4 with a valid username. The result should appear on the coach dashboard.

…

### References
No references

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch
- [ ] PR has 'needs review' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- PR is fully functional
- PR has been tested for [accessibility regressions]
- External dependency files were updated if necessary (node_modules, libraries, etc)
- Documentation is updated
