### PR TITLE
overwrite grade 7 revision test only when same test done on same day

### DIFF
--- a/index.js
+++ b/index.js
@@ -404,19 +404,38 @@ app.post('/overwrite_test', [(req, res,next) => {
 	var course = response['course'];
 	var module = response['module'];
 	var test_date = response['test_date'];
-	
-	db.serialize(() => {
-		/*Run delete statement on responses table using params gathered above*/
-        db.run(`DELETE FROM responses where user_id=(?) and course=(?) and module=(?) and test_date=(?)`,[user_id,course,module,test_date],function(err){
-        	if(err){
-        		console.error(err.message)
-        		res.status(400).send('Could not delete row(s)')
-        		res.end()
-        	}
 
-        })
-	});
+	/*If the course is a grade_7_revision then delete only the specific test done on the same day,*/
+	/*not all tests on the same day in the same course*/
+	/*future work. use array instead of direct string comparison in case other courses need this functionality*/
+	if(course.indexOf("grade7") !== -1){
+		db.serialize(() => {
+				/*Run delete statement on responses table using params gathered above*/
+		        db.run(`DELETE FROM responses where user_id=(?) and test=(?) and course=(?) and module=(?) and test_date=(?)`,[user_id,test_done,course,module,test_date],function(err){
+		        	if(err){
+		        		console.error(err.message)
+		        		res.status(400).send('Could not delete row(s)')
+		        		res.end()
+		        	}
 
+		        })
+			});
+	}
+
+	/*For any other test, delete all tests in the same course done on the same day for that user*/
+	else{
+		db.serialize(() => {
+				/*Run delete statement on responses table using params gathered above*/
+		        db.run(`DELETE FROM responses where user_id=(?) and course=(?) and module=(?) and test_date=(?)`,[user_id,course,module,test_date],function(err){
+		        	if(err){
+		        		console.error(err.message)
+		        		res.status(400).send('Could not delete row(s)')
+		        		res.end()
+		        	}
+
+		        })
+			});
+	}
 	/*send a status of 200 and a success message back to the client*/
 	next();}
 	,(req,res) => {

--- a/public/pmodule/app.js
+++ b/public/pmodule/app.js
@@ -18,10 +18,10 @@ angular.module('passProtect', ['ngAnimate', 'ngSanitize', 'ui.bootstrap','ui', '
     /*Empty usernames array used in whitelist for validation*/
     $scope.usernames = [];
 
-    $scope.existingResponses = []
+    $scope.existingResponses = [];
 
     /*properities used to check whether grade 7 test has already been written by the same learner on the same day*/
-    $scope.grade7_props = ["user_id","test","course","module","test_date"]
+    $scope.grade7_props = ["user_id","test","course","module","test_date"];
 
 
     /*Send get request to endpoint to return all user objects*/
@@ -124,12 +124,13 @@ angular.module('passProtect', ['ngAnimate', 'ngSanitize', 'ui.bootstrap','ui', '
   /*function to concatenate the properities of the a single response object which we need to check for duplicates*/
   /*the default properites used are - user_id  course module test_date*/
   /*this can be overidden with an any array of properties that the testResponse object contains*/
-  function concat_props(response,response_props = ["user_id","course","module","test_date"]) {
+  function concat_props(response,response_props) {
+    response_props = (typeof response_props !== 'undefined') ?  response_props : ["user_id","course","module","test_date"];
     var response_concat = ""
     for (var i in response_props) {
       response_concat = response_concat.concat(response[response_props[i]])
     }
-    
+
     return response_concat
   };
 


### PR DESCRIPTION
### Summary
Grade 7 revision tests were overwriting each other based on course as all other tests do. Users requested that this functionality be modified such that grade 7 tests only overwrite when the same test is written on the same day by the same user for grade 7 revision tests only. This PR provides a solution to the problem by adding extra conditions to the helper functions involved and an extra condition on the server-side deletion.
The behavior of tests in other courses is unaffected.
…

### Reviewer guidance
Submit different grade 7 revision tests with the same username on the same day. They should not overwrite each other unless the same test is submitted by the same user on the same day.
…

### References
Feedback from @jameskuzwao 
…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch
- [ ] PR has 'needs review' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- PR is fully functional
- PR has been tested for [accessibility regressions]
- External dependency files were updated if necessary (node_modules, libraries, etc)
- Documentation is updated
