### PR TITLE
Fix display of grade 7 test panels

### DIFF
--- a/portal/grade_7_revision.html
+++ b/portal/grade_7_revision.html
@@ -51,10 +51,10 @@
             <div class="panel-group">
 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_test1','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     AVERAGE (MEAN)
                                 </h4>
@@ -66,10 +66,10 @@
                 <!-- End Panel -->
 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_test2','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     PROPORTIONS AND RATIOS
                                 </h4>
@@ -81,10 +81,10 @@
                 <!-- End Panel -->
                 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_test3','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     NUMBER BASES
                                 </h4>
@@ -96,10 +96,10 @@
                 <!-- End Panel -->
                 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_test4','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     PROFIT AND LOSS & NOTATION
                                 </h4>
@@ -111,10 +111,10 @@
                 <!-- End Panel -->
 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_test5','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     MONEY AND PERCENTAGE
                                 </h4>
@@ -126,10 +126,10 @@
                 <!-- End Panel -->
 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_test6','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     NOTATION & PLACE VALUES
                                 </h4>
@@ -141,10 +141,10 @@
                 <!-- End Panel -->
 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_test7','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     EQUATION, FACTORS, NEGATIVE NUMBERS
                                 </h4>
@@ -156,10 +156,10 @@
                 <!-- End Panel -->
 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_test8','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     AREA, PERIMETER, SYMMETRY AND VOLUME
                                 </h4>
@@ -171,10 +171,10 @@
                 <!-- End Panel -->                
 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_test9','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     NOTATION, LENGTH AND SHAPES
                                 </h4>
@@ -189,7 +189,7 @@
                 <div class="col-md-8 col-md-offset-2 gr7_test_panel">
                     <a href="#" onclick="window.open('/gr7_test10','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     SETS AND SPEED 
 
@@ -204,7 +204,7 @@
                 <div class="col-md-8 col-md-offset-2 gr7_test_panel">
                     <a href="#" onclick="window.open('/gr7_test11','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     WORD PROBLEMS: NOTATIONS
                                 </h4>
@@ -219,7 +219,7 @@
                 <div class="col-md-8 col-md-offset-2 gr7_test_panel">
                     <a href="#" onclick="window.open('/gr7_test12','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     BASES, ROMAN NUMERALS AND GRAPHS
                                 </h4>
@@ -234,7 +234,7 @@
                 <div class="col-md-8 col-md-offset-2 gr7_test_panel">
                     <a href="#" onclick="window.open('/gr7_test13','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     FRACTIONS
                                 </h4>
@@ -249,7 +249,7 @@
                 <div class="col-md-8 col-md-offset-2 gr7_test_panel">
                     <a href="#" onclick="window.open('/gr7_test14','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_green">
                                 <h4 class="panel-title">
                                     DECIMALS
                                 </h4>
@@ -261,10 +261,10 @@
                 <!-- End Panel -->                
 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_mock1','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_white">
                                 <h4 class="panel-title">
                                     MOCK 1
                                 </h4>
@@ -276,10 +276,10 @@
                 <!-- End Panel -->
 
                 <!-- Begin Panel -->
-                <div class="col-md-8 col-md-offset-2 gr7_test_panel">
+                <div class="col-md-8 col-md-offset-2 gr7_test_panel_container">
                     <a href="#" onclick="window.open('/gr7_mock2','_self')">
                         <div class="panel panel-default">
-                            <div class="panel-heading " id="alpha-heading">
+                            <div class="panel-heading gr7_test_panel_white">
                                 <h4 class="panel-title">
                                     MOCK 2
                                 </h4>

--- a/public/css/portal.css
+++ b/public/css/portal.css
@@ -164,6 +164,21 @@ img .images {
     margin-top: -30px;
 }
 
-.gr7_test_panel a:hover{
+
+.gr7_test_panel_container a:hover{
     text-decoration: none
+}
+
+/*green grade 7 test panel*/
+.gr7_test_panel_green{
+    background-color: #CCFFCC !important;
+    border: #CCFFCC;
+    box-shadow: 2px 2px 2px 2px #3F3F3F;
+}
+
+/*white grade 7 test panel*/
+.gr7_test_panel_white{
+    background-color: white !important;
+    border: #CCFFCC;
+    box-shadow: 2px 2px 2px 2px #3F3F3F;
 }


### PR DESCRIPTION
### Summary
Panels for grade 7 revision tests appear green, while mock tests appear white. Standard CSS classes added for these two types of panels.

…

### Reviewer guidance
Pull the latest branch and access the grade 7 revision page

…

### References
No references

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch
- [ ] PR has 'needs review' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- PR is fully functional
- PR has been tested for [accessibility regressions]
- External dependency files were updated if necessary (node_modules, libraries, etc)
- Documentation is updated
