### PR TITLE
add sex, grade and gr7 exam number to baseline extraction script

### DIFF
--- a/scripts/reporting/baseline.R
+++ b/scripts/reporting/baseline.R
@@ -44,7 +44,7 @@ tresponses<-tresponses %>% mutate(centre=rep(device_name))
 tresponses<-tresponses %>% mutate(valid=rep(1))
 
 #arrange columns, let all columns appear on the left, then all cols from q1...q70 appear on the right
-tresponses<- tresponses %>% select(HEADER,test_date,centre,module ,course,test,valid,testmaxscore,everything())
+tresponses<- tresponses %>% select(HEADER,sex, grade, gr7_exam_number, test_date,centre,module ,course,test,valid,testmaxscore,everything())
 
 #helper function to set empty strings to 0 and otherwise return the actual string
 empty_as_zero<- function(x){


### PR DESCRIPTION
## Summary
This PR adds the fields sex, grade, and gr7_exam_number to the baseline extraction script
…

### Reviewer guidance
Pull the latest changes and attempt to extract baseline tests for any month. The columns sex, grade, and gr7_exam_number should appear in the extract. NA values will appear as empty strings

…

### References
#187 

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch
- [ ] PR has 'needs review' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- PR is fully functional
- PR has been tested for [accessibility regressions]
- External dependency files were updated if necessary (node_modules, libraries, etc)
- Documentation is updated
