### PR TITLE
Use previously downloaded literacy learners list if device is offline

### DIFF
--- a/scripts/get_literacy_usernames.sh
+++ b/scripts/get_literacy_usernames.sh
@@ -38,12 +38,11 @@ else
     # inform the user that the device is offline
     echo "${yellow}Device is Offline${reset}"
     
-    # test if the most recent list exists
-    test -f $literacy_users_file
-    if [ "$?" = "0" ]; then
+    # test if the most recent list exists 
+    if test -f "$literacy_users_file"; then
         # if the file exists, insert it into the database
         echo "${yellow}Could not fetch latest details for Literacy learners. Inserting previously downloaded details..${reset}"
-        Rscript ~/.baseline_testing/scripts/insert_literacy_users_into_baseline.R $literacy_users_file > /dev/null
+        Rscript ~/.baseline_testing/scripts/insert_literacy_users_into_baseline.R "$literacy_users_file" > /dev/null
     else
         # if no recent file exists and the device is offline. print out an error message in red
         echo "${red} Could not fetch latest details for Literacy learners and no previous list was found.."

--- a/scripts/get_literacy_usernames.sh
+++ b/scripts/get_literacy_usernames.sh
@@ -34,15 +34,20 @@ if [[ $? -eq 0 ]]; then
         echo "${red}There was a problem fetching details for literacy learners. Please check your internet connection or try again${reset}"
     fi
 else
-    # if device is offline, insert the most recently
+    # if device is offline, insert the most recently downloaded list
+    # inform the user that the device is offline
     echo "${yellow}Device is Offline${reset}"
     
+    # test if the most recent list exists
     test -f $literacy_users_file
     if [ "$?" = "0" ]; then
+        # if the file exists, insert it into the database
         echo "${yellow}Could not fetch latest details for Literacy learners. Inserting previously downloaded details..${reset}"
         Rscript ~/.baseline_testing/scripts/insert_literacy_users_into_baseline.R $literacy_users_file > /dev/null
     else
+        # if no recent file exists and the device is offline. print out an error message in red
         echo "${red} Could not fetch latest details for Literacy learners and no previous list was found.."
+        # inform the user to check their internet connection and try again
         echo "Please check your internet connection and try again. If the problem persists, contact support ${reset}"
     fi
 

--- a/scripts/get_literacy_usernames.sh
+++ b/scripts/get_literacy_usernames.sh
@@ -34,7 +34,16 @@ if [[ $? -eq 0 ]]; then
         echo "${red}There was a problem fetching details for literacy learners. Please check your internet connection or try again${reset}"
     fi
 else
-    echo "${yellow}Device is Offline"
-    echo "Could not fetch details for Literacy learners"
-    echo "Please check your internet connection and try again. If the problem persists, contact support ${reset}"
+    # if device is offline, insert the most recently
+    echo "${yellow}Device is Offline${reset}"
+    
+    test -f $literacy_users_file
+    if [ "$?" = "0" ]; then
+        echo "${yellow}Could not fetch latest details for Literacy learners. Inserting previously downloaded details..${reset}"
+        Rscript ~/.baseline_testing/scripts/insert_literacy_users_into_baseline.R $literacy_users_file > /dev/null
+    else
+        echo "${red} Could not fetch latest details for Literacy learners and no previous list was found.."
+        echo "Please check your internet connection and try again. If the problem persists, contact support ${reset}"
+    fi
+
 fi

--- a/sql/08assignmembership.sql
+++ b/sql/08assignmembership.sql
@@ -136,6 +136,7 @@ LOOP
 				FROM  	ext.kolibriauth_collection
 				where   subscriptions LIKE playListID
 				and kind = 'learnergroup'
+				-- TODO : use channel name instead of length of channel subscriptions to select the next channel id
 				AND  length (subscriptions) = (SELECT min( length (subscriptions) )FROM  ext.kolibriauth_collection
 				where    subscriptions LIKE  playListID
 				and kind = 'learnergroup' );


### PR DESCRIPTION
### Summary
When a literacy device is offline and the learners list is reloaded, the literacy learners are cleared and not added to the database because the latest list has not been fetched from the cloud server. This PR adds extra conditions to the get_literacy_learners script to insert the most recently downloaded literacy learners file into the database if the device is offline. All other conditions remain the same and the list is updated if the device is offline.
…

### Reviewer guidance
On a device with literacy settings enabled, follow the following steps:
1. Restart the application while connected to an active internet connection
2. Restart the application again without an active internet connection

The coach dashboard will show literacy learners based on the list that was fetched when the device was connected to the internet.


…

### References
No references
…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch
- [ ] PR has 'needs review' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- PR is fully functional
- PR has been tested for [accessibility regressions]
- External dependency files were updated if necessary (node_modules, libraries, etc)
- Documentation is updated
